### PR TITLE
Fix scroll controls outside canvas

### DIFF
--- a/advicemegang-main/advicemegang-main/src/App.tsx
+++ b/advicemegang-main/advicemegang-main/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { Canvas } from '@react-three/fiber';
 import { ScrollControls } from "@react-three/drei";
-import CarScene from './scenes/CarScene';
+import CarSceneContent from './scenes/CarScene';
 import AppNavBar from './components/AppNavBar';
 import HeroSection from './components/HeroSection';
 import FeaturesSection from './components/FeaturesSection';
@@ -16,18 +17,23 @@ export default function App() {
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <ScrollControls pages={4} damping={0.25}>
-          {/* 3D Scene in the background */}
-          <CarScene />
+        
+        {/* 3D Canvas with ScrollControls */}
+        <div className="fixed inset-0 z-0">
+          <Canvas gl={{ antialias: true }} camera={{ position: [10, 5, 10], fov: 35 }}>
+            <ScrollControls pages={4} damping={0.25}>
+              <CarSceneContent />
+            </ScrollControls>
+          </Canvas>
+        </div>
 
-          {/* HTML content in the foreground */}
-          <div className="relative z-10">
-            <AppNavBar />
-            <HeroSection />
-            <FeaturesSection />
-            <Footer />
-          </div>
-        </ScrollControls>
+        {/* HTML content in the foreground */}
+        <div className="relative z-10">
+          <AppNavBar />
+          <HeroSection />
+          <FeaturesSection />
+          <Footer />
+        </div>
       </TooltipProvider>
     </ThemeProvider>
   );

--- a/advicemegang-main/advicemegang-main/src/scenes/CarScene.tsx
+++ b/advicemegang-main/advicemegang-main/src/scenes/CarScene.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useRef, useEffect } from 'react';
-import { useFrame, Canvas } from '@react-three/fiber';
+import { useFrame } from '@react-three/fiber';
 import { useGLTF, useScroll } from '@react-three/drei';
 
 // CarModel Component with fallback
@@ -62,20 +62,18 @@ function CarModel() {
 // Path is updated here as well
 useGLTF.preload("/cyberpunk-car.glb");
 
-// Main Scene Component
-export default function CarScene() {
+// Scene Content Component (to be used inside Canvas and ScrollControls)
+export default function CarSceneContent() {
   return (
-    <Canvas gl={{ antialias: true }} camera={{ position: [10, 5, 10], fov: 35 }}>
-      <Suspense fallback={null}>
-        <ambientLight intensity={0.5} />
-        <directionalLight position={[0, 10, 5]} intensity={1} />
-        <spotLight position={[10, 10, 10]} angle={0.15} penumbra={1} intensity={2} castShadow />
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1, 0]}>
-          <planeGeometry args={[100, 100]} />
-          <meshStandardMaterial color="#1a1a1a" />
-        </mesh>
-        <CarModel />
-      </Suspense>
-    </Canvas>
+    <Suspense fallback={null}>
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[0, 10, 5]} intensity={1} />
+      <spotLight position={[10, 10, 10]} angle={0.15} penumbra={1} intensity={2} castShadow />
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1, 0]}>
+        <planeGeometry args={[100, 100]} />
+        <meshStandardMaterial color="#1a1a1a" />
+      </mesh>
+      <CarModel />
+    </Suspense>
   );
 };


### PR DESCRIPTION
Move `ScrollControls` inside `Canvas` component to resolve R3F hook usage error.

The `ScrollControls` component from `@react-three/drei` and its internal hooks (`useStore`, `useThree`) must be rendered within a `<Canvas>` component from `@react-three/fiber` to access the necessary R3F context. This change refactors the application to ensure `ScrollControls` operates within the `Canvas` context, allowing R3F hooks to function correctly and fixing the "Hooks can only be used within the Canvas component!" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-05875601-a6a3-4145-9eb5-fd1510ca4e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05875601-a6a3-4145-9eb5-fd1510ca4e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>